### PR TITLE
Add pinned message creation panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,6 +339,83 @@
       .support-panel[hidden] {
         display: none;
       }
+
+      .pinned-banner {
+        background: rgba(56, 189, 248, 0.12);
+        border: 1px solid rgba(56, 189, 248, 0.35);
+        border-radius: 18px;
+        padding: 18px 20px;
+        display: grid;
+        gap: 10px;
+      }
+
+      .pinned-banner h2 {
+        margin: 0;
+        font-size: 1.1rem;
+        color: #e0f2fe;
+      }
+
+      .pinned-banner p {
+        margin: 0;
+        color: #e2e8f0;
+      }
+
+      .pinned-banner a {
+        color: #7dd3fc;
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      .pinned-panel {
+        background: rgba(30, 41, 59, 0.75);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 20px;
+        padding: 24px clamp(18px, 4vw, 32px);
+        display: grid;
+        gap: 16px;
+      }
+
+      .pinned-panel h2 {
+        margin: 0;
+        color: #f8fafc;
+        font-size: 1.3rem;
+      }
+
+      .pinned-form {
+        display: grid;
+        gap: 12px;
+      }
+
+      .pinned-form label {
+        font-size: 0.9rem;
+        color: #cbd5f5;
+        display: grid;
+        gap: 8px;
+      }
+
+      .pinned-form textarea {
+        width: 100%;
+        min-height: 120px;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(15, 23, 42, 0.8);
+        color: #e2e8f0;
+        font-size: 0.95rem;
+        resize: vertical;
+      }
+
+      .pinned-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+      }
+
+      .pinned-helper {
+        font-size: 0.85rem;
+        color: #94a3b8;
+      }
     </style>
   </head>
   <body>
@@ -366,6 +443,16 @@
     </div>
 
     <main>
+      <section class="pinned-banner" id="pinnedBanner" hidden>
+        <h2>Angeheftete Nachricht</h2>
+        <p id="pinnedMessage">
+          Deine Nachricht erscheint hier und bleibt oben sichtbar.
+        </p>
+        <a id="pinnedDownload" href="#" download="pinned-message.txt">
+          TXT-Datei herunterladen
+        </a>
+      </section>
+
       <header>
         <span class="eyebrow">XMenu Hauptseite</span>
         <h1>Dein nächstes Ipad erlebnis beginnt mit XMenu.</h1>
@@ -394,6 +481,30 @@
           <h2>Ständige Weiterentwicklung</h2>
           <p>Regelmäßige Updates und neue Funktionen.</p>
         </div>
+      </section>
+
+      <section class="pinned-panel">
+        <div>
+          <h2>Pinned Message erstellen</h2>
+          <p>
+            Erstelle eine angeheftete Nachricht. Die Nachricht wird oben angezeigt und als
+            TXT-Datei gespeichert.
+          </p>
+        </div>
+        <form class="pinned-form" id="pinnedForm">
+          <label>
+            Nachricht
+            <textarea
+              name="pinnedMessage"
+              placeholder="Schreibe deine angeheftete Nachricht…"
+              required
+            ></textarea>
+          </label>
+          <div class="pinned-actions">
+            <button class="button primary" type="submit">Pinned Message speichern</button>
+            <span class="pinned-helper">Die Datei wird als pinned-message.txt erstellt.</span>
+          </div>
+        </form>
       </section>
 
       <section class="support-panel" id="supportPanel" hidden>
@@ -472,10 +583,15 @@
       const supportToggle = document.getElementById("supportToggle");
       const supportPanel = document.getElementById("supportPanel");
       const supportForm = document.getElementById("supportForm");
+      const pinnedForm = document.getElementById("pinnedForm");
+      const pinnedBanner = document.getElementById("pinnedBanner");
+      const pinnedMessage = document.getElementById("pinnedMessage");
+      const pinnedDownload = document.getElementById("pinnedDownload");
 
       let index = 0;
       let done = false;
       let timerId = null;
+      let pinnedFileUrl = null;
 
       const total = assets.length;
 
@@ -546,6 +662,25 @@
         );
 
         window.location.href = `mailto:cool73800@gmail.com?subject=${subject}&body=${body}`;
+      });
+
+      pinnedForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const formData = new FormData(pinnedForm);
+        const message = formData.get("pinnedMessage").trim();
+
+        if (!message) return;
+
+        pinnedMessage.textContent = message;
+        pinnedBanner.removeAttribute("hidden");
+
+        const fileContent = `Pinned Message\n\n${message}\n`;
+        const fileBlob = new Blob([fileContent], { type: "text/plain" });
+        if (pinnedFileUrl) {
+          URL.revokeObjectURL(pinnedFileUrl);
+        }
+        pinnedFileUrl = URL.createObjectURL(fileBlob);
+        pinnedDownload.href = pinnedFileUrl;
       });
 
       start();


### PR DESCRIPTION
### Motivation
- Provide a simple UI to compose a short pinned message that appears at the top of the page and can be exported as a TXT file. 

### Description
- Add styles for a pinned banner and creation panel and include a new banner element at the top of `index.html` that is hidden until a message is created. 
- Add a `pinned-panel` section with a form and textarea to compose the pinned message. 
- Wire client-side logic to render the message in the banner, generate a `Blob` with the TXT content, create a download URL and attach it to an anchor for `pinned-message.txt`, and revoke old object URLs when updated. 
- All changes are applied to `index.html` (CSS, markup and script updates). 

### Testing
- Started a local server with `python -m http.server 8000` and verified the page is served with `curl -I http://127.0.0.1:8000/index.html` which returned `HTTP/1.0 200 OK`. 
- Inspected the modified file with `nl -ba index.html` to confirm the inserted banner, panel and script changes are present. 
- Attempted end-to-end interaction using Playwright to fill the pinned-message form and capture a screenshot, but the Playwright runs timed out and did not complete; no successful E2E screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69834fc49718832d98589c2942d566d5)